### PR TITLE
WIP: fix Travis CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ services:
 install:
   - pip install -U pip
   - pip --version
-  - pip install ansible ansible-lint yamllint flake8 molecule docker molecule-openstack
+  - pip install ansible ansible-lint yamllint flake8 molecule docker
+  - pip install molecule-openstack
   - ansible --version
   - ansible-lint --version
   - yamllint --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 install:
   - pip install -U pip
   - pip --version
-  - pip install ansible ansible-lint yamllint flake8 molecule docker
+  - pip install ansible ansible-lint yamllint flake8 molecule docker molecule-openstack
   - ansible --version
   - ansible-lint --version
   - yamllint --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,3 @@ script:
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
-
-branches:
-  only:
-  - /.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ script:
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
+
+branches:
+  only:
+  - /.*/

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,7 @@
 galaxy_info:
   author: Ian Tewksbury, Christian Stankowic
-  description: Ansible role for configuring logical volumes and mount points for Foreman/Katello and Red Hat Satellite Servers and Proxy Servers/Capsules
+  description: Configuring storage for Foreman/Katello and Red Hat Satellite
   company: Red Hat, Inc.
-  issue_tracker_url: https://github.com/RedHatOfficial/ansible-role-redhat_satellite6_storage/issues
   license: GPLv3
   min_ansible_version: 2.8
   platforms:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,9 +18,9 @@ platforms:
       - "customize ['storageattach', :id,  '--storagectl', 'IDE', '--port', 1, '--device', 0, '--type', 'hdd', '--medium', 'second_disk.vdi']"
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
 verifier:
   name: testinfra
-  lint:
-    name: flake8
+lint: |
+    yamllint .
+    ansible-lint
+    flake8

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -8,6 +8,7 @@ TESTINFRA_HOSTS = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']
 ).get_hosts('all')
 
+
 def test_packages(host):
     """
     check if packages are installed
@@ -18,6 +19,7 @@ def test_packages(host):
     for pkg in ansible_vars["ansible_facts"]["core_packages"]:
         assert host.package(pkg).is_installed
 
+
 def test_storage(host):
     """
     test if storage was set-up correctly
@@ -25,7 +27,9 @@ def test_storage(host):
     # get variables from file
     ansible_vars = host.ansible("include_vars", "file=main.yml")
     # check LVM PV
-    assert host.file("/dev/" + ansible_vars["ansible_facts"]["satellite_vg"]).exists
+    assert host.file(
+        "/dev/" + ansible_vars["ansible_facts"]["satellite_vg"]
+        ).exists
     # check file systems
     for filesys in ansible_vars["ansible_facts"]["satellite_mounts"]:
         assert host.mount_point(filesys).exists

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -4,8 +4,6 @@ dependency:
     role-file: molecule/shared/requirements.yml
 driver:
   name: docker
-lint:
-  name: yamllint
   options:
     config-file: tests/yamllint.yml
 platforms:
@@ -19,8 +17,6 @@ platforms:
     #   - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
   playbooks:
     prepare: ../shared/prepare.yml
     converge: ../shared/playbook.yml
@@ -34,10 +30,12 @@ verifier:
     # Add a -v so you see the individual test names,
     # particularly useful with parameterized tests
     v: true
-  lint:
-    name: flake8
   # Using the shared directory is useful for sharing tests across scenarios,
   # but is not a requirement. For scenario specific tests, add the appropriate
   # file path to the test or test directory below
   additional_files_or_dirs:
     - ../../shared/tests
+lint: |
+    yamllint .
+    ansible-lint
+    flake8

--- a/molecule/openstack/molecule.yml
+++ b/molecule/openstack/molecule.yml
@@ -4,16 +4,12 @@ dependency:
     role-file: molecule/shared/requirements.yml
 driver:
   name: openstack
-lint:
-  name: yamllint
   options:
     config-file: tests/yamllint.yml
 platforms:
   - name: test-redhat_satellite6_storage
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
   playbooks:
     prepare: ../shared/prepare.yml
     converge: ../shared/playbook.yml
@@ -27,10 +23,12 @@ verifier:
     # Add a -v so you see the individual test names,
     # particularly useful with parameterized tests
     v: true
-  lint:
-    name: flake8
   # Using the shared directory is useful for sharing tests across scenarios,
   # but is not a requirement. For scenario specific tests, add the appropriate
   # file path to the test or test directory below
   additional_files_or_dirs:
     - ../../shared/tests
+lint: |
+    yamllint .
+    ansible-lint
+    flake8

--- a/molecule/shared/playbook.yml
+++ b/molecule/shared/playbook.yml
@@ -1,5 +1,5 @@
 - name: converge
   hosts: all
   roles:
-    - role: redhat_satellite6_storage
+    - role: ansible-role-redhat_satellite6_storage
   post_tasks: []


### PR DESCRIPTION
(*See also issue #4*)

Problems to resolve:
- [ ] find a way to add a second disk to the testing image (*e.g. `/dev/sdb`, `/dev/vdb`,...*)
- [ ] decide whether to still support Python 2.7 - it's **EOL** and first Python modules required for testing (*`molecule-openstack`*) aren't available anymore